### PR TITLE
Decrease fake libc requirement version to support Ubuntu 18.04

### DIFF
--- a/kumk
+++ b/kumk
@@ -342,7 +342,7 @@ do_config_pkg(){
     else
         which dkms >/dev/null && do_dkms ${VER_LONG}
     fi
-    sed "/Depends: linux-headers-${VER_LONG/-generic}, libc6/s/libc6 (>= 2...)/libc6 (>= 2.31)/" -i /var/lib/dpkg/status
+    sed "/Depends: linux-headers-${VER_LONG/-generic}, libc6/s/libc6 (>= 2...)/libc6 (>= 2.27)/" -i /var/lib/dpkg/status
 }
 
 purge_kernel(){


### PR DESCRIPTION
Ubuntu 18.04.6 comes with `2.27-3ubuntu1.4` at the moment.