### PR TITLE
Fixed ramdisk for kernels 6.4.4+

### DIFF
--- a/kumk
+++ b/kumk
@@ -67,6 +67,7 @@ set_locale(){
             installing_package="instaluji balíček"
             installing_only_unpacking_package="instaluji/rozbaluji_pouze balíček"
             installing_rest="instaluji zbylé:"
+            installing_kernel_version_gt_060403_req_module_unpack="instalovaná verze jádra je >6.4.3, rozbaluji moduly a opravuji initrd..."
             and="a"
             installing_kernel_version_le_51116_install_normal="instalovaná verze jádra je <=5.11.16, instaluju normálně..."
             install_canceled="Instalace zrušena..."
@@ -134,6 +135,7 @@ set_locale(){
             installing_package="installing package"
             installing_only_unpacking_package="installing/only_unpacking package"
             installing_rest="installing rest:"
+            installing_kernel_version_gt_060403_req_module_unpack="installing kernel version >6.4.3, decompressing modules and fixing initrd..."
             and="and"
             installing_kernel_version_le_51116_install_normal="installing kernel version <=5.11.16, install normal..."
             install_canceled="Install canceled..."
@@ -315,6 +317,10 @@ install_kernel(){
                 ewarnt "$(basename $(ls ${DATA}/${VER}/linux-image*.deb))"
                 ewarnt "$(basename $(ls ${DATA}/${VER}/linux-module*.deb))"
                 dpkg -i ${DATA}/${VER}/linux-image*.deb ${DATA}/${VER}/linux-module*.deb >/dev/null
+                if (dpkg --compare-versions "${VER}" "gt" "6.4.3"); then
+                  ewarn "${installing_kernel_version_gt_060403_req_module_unpack}"
+                  do_fix_compressed_modules
+                fi
             else
                 ewarn "${installing_kernel_version_le_51116_install_normal}"
                 dpkg -i ${DATA}/${VER}/*.deb >/dev/null
@@ -330,6 +336,10 @@ install_kernel(){
 
 check_depends(){
     depends_packages=( binutils )
+    if (dpkg --compare-versions "${VER}" "gt" "6.4.3"); then
+      depends_packages+=( zstd )
+    fi
+
     for package in ${depends_packages[@]}; do
         dpkg -l ${package} | grep -q '^ii' || need_install_depends+=" ${package}"
     done
@@ -404,6 +414,13 @@ do_config_pkg(){
         ewarnt "${workarounding_depends_on_unavailable_libssl3_faking_to_libssl1}"
         sed "/Depends: linux-headers-${VER_LONG/-generic}.*libssl3/s/libssl3[^)]*)/libssl1.1 (>= 1.1.0)/" -i /var/lib/dpkg/status
     } || true
+}
+
+do_fix_compressed_modules(){
+  VER_LONG=$(ls -d /usr/src/linux-headers-${VER/-rc/*rc}*${MODE} | sed 's/.*headers-//')
+  sudo find /lib/modules/${VER_LONG} -name '*.zst' -exec zstd -d {} \; >/dev/null 2>/dev/null
+  sudo depmod -a -F /boot/System.map-${VER_LONG} ${VER_LONG}
+  sudo update-initramfs -k ${VER_LONG} -u
 }
 
 purge_kernel(){

--- a/kumk
+++ b/kumk
@@ -6,7 +6,7 @@ set -e
 
 VERSION="0.6.14"
 
-URL="https://kernel.ubuntu.com/~kernel-ppa/mainline"
+URL="https://kernel.ubuntu.com/~kernel-ppa/mainline/"
 DATA=/tmp/kumk
 [[ ! $2 = *lowlatency* ]] && MODE="generic" ||  MODE="lowlatency"
 TMP="${DATA}/tmp"
@@ -231,8 +231,7 @@ detect_arch(){
 }
 
 check_url_available(){
-    URL_PING="$(echo "${URL}" | sed 's#.*://##;s#/.*##')"
-    ping -c1 ${URL_PING} &>/dev/null || {
+    wget --spider -q -O /dev/null "${URL}" || {
         set_locale
         eerror "${error_server_or_internet_not_available}"
         exit

--- a/kumk
+++ b/kumk
@@ -397,13 +397,13 @@ do_copy_bin(){
 
 do_config_pkg(){
     dpkg --compare-versions "${VER}" "ge" "5.15.7" && {
-        (dpkg -l libssl3 2>/dev/null | grep -q '^ii \+libssl3') || ignore_libssl3=",libssl3"
+        (dpkg -l libssl3 2>/dev/null | grep -q '^ii \+libssl3') || ignore_libssl3=",libssl3,libssl3t64"
     }
 
     if (dpkg -l | grep linux-headers-${VER_LONG} | grep -q ^iU); then
         set_locale
         ewarn "${configuring_package_linux_header_ver_long_with_ignoring_depends_on_libc6_version}"
-        dpkg --configure --ignore-depends=libc6${ignore_libssl3} linux-headers-${VER_LONG} >/dev/null
+        dpkg --configure --ignore-depends=libc6,libelf1t64,libzstd1${ignore_libssl3} linux-headers-${VER_LONG} >/dev/null
     else
         which dkms >/dev/null && do_dkms ${VER_LONG}
     fi
@@ -418,7 +418,7 @@ do_config_pkg(){
 
 do_fix_compressed_modules(){
   VER_LONG=$(ls -d /usr/src/linux-headers-${VER/-rc/*rc}*${MODE} | sed 's/.*headers-//')
-  sudo find /lib/modules/${VER_LONG} -name '*.zst' -exec zstd -d {} \; >/dev/null 2>/dev/null
+  sudo find /lib/modules/${VER_LONG} -name '*.zst' -exec zstd -fd {} \; >/dev/null 2>/dev/null
   sudo depmod -a -F /boot/System.map-${VER_LONG} ${VER_LONG}
   sudo update-initramfs -k ${VER_LONG} -u
 }

--- a/kumk
+++ b/kumk
@@ -408,6 +408,7 @@ do_config_pkg(){
         which dkms >/dev/null && do_dkms ${VER_LONG}
     fi
 
+    sed "/Depends: linux-headers-${VER_LONG/-generic}, libc6/s/libelf1t64 (>= [^)]*), //" -i /var/lib/dpkg/status
     sed "/Depends: linux-headers-${VER_LONG/-generic}, libc6/s/libc6 (>= 2...)/libc6 (>= ${libc6_ver})/" -i /var/lib/dpkg/status
 
     [[ ${ignore_libssl3} ]] && {


### PR DESCRIPTION
In 6.4.4, mainline kernels contain all modules compressed with zstd. This interferes with initramfs generation, which requires the uncompressed modules.

Without this fix, running any kernel 6.4.4+ doesn't work, ends in rescue shell telling there is no root device (because no modules are present, so there is no disk driver).